### PR TITLE
[WIP] Add concurrency for "download-syntax" module & support many args for --only parameter

### DIFF
--- a/bin/download-syntax
+++ b/bin/download-syntax
@@ -11,10 +11,16 @@ import tempfile
 import textwrap
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from pathlib import Path
+from sys import stderr
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import NamedTuple
 from typing import Optional
+from typing import Sequence
 from typing import Set
 from typing import Tuple
 
@@ -24,8 +30,8 @@ HEADER_RE = re.compile('^#+ ', re.MULTILINE)
 TRAILING_WS_RE = re.compile(r'\s+$', re.MULTILINE)
 
 _STRATEGIES = (json.loads, cson.loads, plistlib.loads)
-_GRAMMAR_DIR = 'share/babi/grammar_v1'
-_LICENSE_DIR = 'licenses'
+_GRAMMAR_DIR = Path('share/babi/grammar_v1')
+_LICENSE_DIR = Path('licenses')
 
 
 class Repo(NamedTuple):
@@ -288,89 +294,138 @@ def _ts_to_js(scope: str, dct: Dict[str, Any]) -> Dict[str, Any]:
     return ret
 
 
-def _download(*, only: Optional[str]) -> int:
-    assert os.path.exists(_GRAMMAR_DIR)
-    assert os.path.exists(_LICENSE_DIR)
-
-    licenses: Set[str] = set()
-    grammars: Set[str] = set()
-
-    for repo in REPOS:
-        if only is not None and repo.name != only:
+def _load_grammar_string(grammar_string: str, strategies: Sequence[Callable]):
+    for strategy in strategies:
+        try:
+            loaded_grammar = strategy(grammar_string)
+        except Exception:
             continue
-        print(f'{repo.name}...')
+        else:
+            return loaded_grammar
+    raise AssertionError(f'could not parse "{grammar_string}"')
 
-        licenses.add(repo.license_filename)
 
-        license_path, _, header = repo.license_path.partition('#')
-        license_url = repo.url(license_path)
-        license_s = urllib.request.urlopen(license_url).read().decode()
+def _download_grammar(repo: Repo, grammar: str) -> Path:
+    grammar_string = urllib.request.urlopen(repo.url(grammar)).read()
+    loaded_grammar = _load_grammar_string(grammar_string, _STRATEGIES)
+    grammar_filepath = _GRAMMAR_DIR / f'{loaded_grammar["scopeName"]}.json'
+    with grammar_filepath.open('w', encoding='utf-8') as f:
+        json.dump(loaded_grammar, f)
+        f.write('\n')
+    return grammar_filepath
 
-        if header:
-            sections = HEADER_RE.split(license_s)
-            for section in sections:
-                if section.startswith(header):
-                    _, _, license_s = section.partition('\n')
-                    break
+
+def _parse_license_with_header(license_string: str, header: str) -> Optional[str]:
+    sections = HEADER_RE.split(license_string)
+    for section in sections:
+        if not section.startswith(header):
+            continue
+        _, _, section_body = section.partition('\n')
+        return section_body
+
+
+def _download_repo_license(repo: Repo):
+    license_path, _, header = repo.license_path.partition('#')
+    license_url = repo.url(license_path)
+    license_string = urllib.request.urlopen(license_url).read().decode()
+
+    if header:
+        license_string = _parse_license_with_header(license_string, header)
+        if license_string is None:
+            raise AssertionError(f'license not found "{repo.license_path}" for "{repo.name}"')
+
+    # some licenses have trailing whitespace, ugh
+    license_string = TRAILING_WS_RE.sub('', license_string)
+
+    with open(os.path.join(_LICENSE_DIR, repo.license_filename), 'w', encoding='utf-8') as f:
+        f.write(f'LICENSE retrieved from {license_url}\n\n')
+        f.write(f'{"-" * 79}\n\n')
+        f.write(f'{license_string.rstrip()}\n')
+
+
+def _download_repo(repo: Repo) -> Tuple[Path, Set[Path]]:
+    print(f'{repo.name}...')
+    _download_repo_license(repo)
+    license_filepath = _LICENSE_DIR / repo.license_filename
+
+    grammars_filepaths = set()
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(_download_grammar, repo, grammar): grammar for grammar in repo.grammars}
+        for future in as_completed(futures):
+            try:
+                downloaded_grammar_filepath = future.result()
+            except Exception as e:
+                print(f'error while downloading grammar "{futures[future]}": {e}', file=stderr)
+                continue
             else:
-                raise AssertionError(f'not found {repo.license_path}')
+                grammars_filepaths.add(downloaded_grammar_filepath)
+    return license_filepath, grammars_filepaths
 
-        # some licenses have trailing whitespace, ugh
-        license_s = TRAILING_WS_RE.sub('', license_s)
 
-        with open(os.path.join(_LICENSE_DIR, repo.license_filename), 'w') as f:
-            f.write(f'LICENSE retrieved from {license_url}\n\n')
-            f.write(f'{"-" * 79}\n\n')
-            f.write(f'{license_s.rstrip()}\n')
+def _download(*, only: Set[str]) -> int:
+    assert _GRAMMAR_DIR.exists()
+    assert _LICENSE_DIR.exists()
 
-        for grammar in repo.grammars:
-            grammar_s = urllib.request.urlopen(repo.url(grammar)).read()
-            for strategy in _STRATEGIES:
-                try:
-                    loaded = strategy(grammar_s)
-                except Exception:
-                    continue
-                else:
-                    break
+    licenses: Set[Path] = set()
+    grammars: Set[Path] = set()
+
+    repos = REPOS
+    if only:
+        repos = [repo for repo in repos if repo.name in only]
+
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(_download_repo, repo): repo for repo in repos}
+
+        if not futures and only:
+            print(
+                'Nothing to do. Make sure you provided correct repo names to the "only" parameter',
+                file=stderr
+            )
+            return 1
+
+        for future in as_completed(futures):
+            try:
+                license_filepath, grammars_filepaths = future.result()
+            except Exception as e:
+                print(f'error downloading repo {futures[future]}: {e}', file=stderr)
+                continue
             else:
-                raise AssertionError(f'could not parse {grammar}')
-
-            grammar_name = f'{loaded["scopeName"]}.json'
-            grammars.add(grammar_name)
-            with open(os.path.join(_GRAMMAR_DIR, grammar_name), 'w') as f:
-                json.dump(loaded, f)
-                f.write('\n')
+                licenses.add(license_filepath)
+                grammars.update(grammars_filepaths)
 
     # similar to what vs code does, derive javascript from typescript
-    if only is None or only == 'microsoft/TypeScript-TmLanguage':
-        with open(os.path.join(_GRAMMAR_DIR, 'source.tsx.json')) as f:
+    if 'microsoft/TypeScript-TmLanguage' in repos:
+        with _GRAMMAR_DIR.joinpath('source.tsx.json').open(encoding='utf-8') as f:
             tsx = json.load(f)
 
         for scope in ('.js', '.js.jsx'):
-            grammar_name = f'source{scope}.json'
-            grammars.add(grammar_name)
-            with open(os.path.join(_GRAMMAR_DIR, grammar_name), 'w') as f:
+            grammar_filepath = _GRAMMAR_DIR / f'source{scope}.json'
+            grammars.add(grammar_filepath)
+            with grammar_filepath.open('w', encoding='utf-8') as f:
                 json.dump(_ts_to_js(scope, tsx), f)
                 f.write('\n')
 
-    if only is None:
-        existing_licenses = set(os.listdir(_LICENSE_DIR))
+    if not only:
+        existing_licenses = set(_LICENSE_DIR.iterdir())
         for victim in existing_licenses - licenses:
-            os.remove(os.path.join(_LICENSE_DIR, victim))
-        existing_grammars = set(os.listdir(_GRAMMAR_DIR))
+            victim.unlink()
+        existing_grammars = set(_GRAMMAR_DIR.iterdir())
         for victim in existing_grammars - grammars:
-            os.remove(os.path.join(_GRAMMAR_DIR, victim))
+            victim.unlink()
     else:
-        licenses = set(os.listdir(_LICENSE_DIR))
-        grammars = set(os.listdir(_GRAMMAR_DIR))
+        licenses = set(_LICENSE_DIR.iterdir())
+        grammars = set(_GRAMMAR_DIR.iterdir())
 
     cfg = configparser.ConfigParser()
-    cfg.read('setup.cfg')
+    setup_cfg_filepath = Path('setup.cfg')
+    cfg.read(setup_cfg_filepath)
 
-    license_files = sorted(os.path.join(_LICENSE_DIR, f) for f in licenses)
+    # we use Path.as_posix() everywhere to make sure that paths (slashes vs backslashes)
+    # are reproducible on each supported platform (hi Windows)
+    license_files = sorted(license.as_posix() for license in licenses)
     cfg['metadata']['license_files'] = '\n' + '\n'.join(license_files)
-    grammar_files = sorted(os.path.join(_GRAMMAR_DIR, f) for f in grammars)
-    cfg['options.data_files'][_GRAMMAR_DIR] = '\n' + '\n'.join(grammar_files)
+    grammar_files = sorted(grammar.as_posix() for grammar in grammars)
+    cfg['options.data_files'][_GRAMMAR_DIR.as_posix()] = '\n' + '\n'.join(grammar_files)
 
     sio = io.StringIO()
     cfg.write(sio)
@@ -378,78 +433,102 @@ def _download(*, only: Optional[str]) -> int:
     new_contents = new_contents.replace('\t', '    ')
     new_contents = new_contents.replace(' \n', '\n')
 
-    with open('setup.cfg', 'w') as f:
+    with setup_cfg_filepath.open('w', encoding='utf-8') as f:
         f.write(new_contents)
 
     return 0
 
 
-def _update(*, only: Optional[str]) -> int:
-    new = []
-    for repo in REPOS:
-        if only is not None and repo.name != only:
-            new.append(repo)
-            continue
+def _update_repo(repo: Repo) -> Repo:
+    print(f'Updating {repo.name}... ')
 
-        print(f'{repo.name} ... ', end='', flush=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        git = ('git', '-C', tmpdir)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            git = ('git', '-C', tmpdir)
+        url = f'https://github.com/{repo.name}'
+        clone_cmd = (*git, 'clone', '--no-checkout', '-q', url, '.')
+        subprocess.check_call(clone_cmd)
 
-            url = f'https://github.com/{repo.name}'
-            clone_cmd = (*git, 'clone', '--no-checkout', '-q', url, '.')
-            subprocess.check_call(clone_cmd)
+        branches_cmd = (*git, 'branch', '-r', '--contains', repo.version)
+        branches_s = subprocess.check_output(branches_cmd).decode()
+        branches = [branch.strip() for branch in branches_s.splitlines()]
 
-            branches_cmd = (*git, 'branch', '-r', '--contains', repo.version)
-            branches_s = subprocess.check_output(branches_cmd).decode()
-            branches = [branch.strip() for branch in branches_s.splitlines()]
+        if not branches:
+            raise SystemExit(f'orphaned commit {repo.name}')
+        elif branches[0].startswith('origin/HEAD -> '):
+            _, _, branch = branches[0].rpartition(' ')
+        else:
+            branch = branches[0]
 
-            if not branches:
-                raise SystemExit(f'orphaned commit {repo.name}')
-            elif branches[0].startswith('origin/HEAD -> '):
-                _, _, branch = branches[0].rpartition(' ')
-            else:
-                branch = branches[0]
+        version_cmd = (
+            *git, 'log', '-1', '--format=%h', branch, '--', *repo.grammars,
+        )
+        version = subprocess.check_output(version_cmd).decode().strip()
 
-            version_cmd = (
-                *git, 'log', '-1', '--format=%h', branch, '--', *repo.grammars,
+        ancestor_cmd = (
+            *git, 'merge-base', '--is-ancestor', version, repo.version,
+        )
+
+        if (
+                repo.version == 'HEAD' or
+                version != repo.version and subprocess.call(ancestor_cmd)
+        ):
+            print(f'Updated {repo.name} {repo.version} => {version}')
+            return repo._replace(version=version)
+
+        print(f'{repo.name} is up to date!')
+        return repo
+
+
+def _update(*, only: Set[str]) -> int:
+    up_to_date_repos = []
+    with ThreadPoolExecutor() as executor:
+        futures = {}
+
+        for repo in REPOS:
+            if only and repo.name not in only:
+                up_to_date_repos.append(repo)
+                continue
+            futures[executor.submit(_update_repo, repo)] = repo
+
+        if not futures and only:
+            print(
+                'Nothing to do. Make sure you provided correct repo names to the "only" parameter',
+                file=stderr
             )
-            version = subprocess.check_output(version_cmd).decode().strip()
+            return 1
 
-            ancestor_cmd = (
-                *git, 'merge-base', '--is-ancestor', version, repo.version,
-            )
-            if (
-                    repo.version == 'HEAD' or
-                    version != repo.version and subprocess.call(ancestor_cmd)
-            ):
-                print(f'{repo.version} => {version}')
-                new.append(repo._replace(version=version))
+        for future in as_completed(futures):
+            try:
+                updated_repo = future.result()
+            except Exception as e:
+                print(f'error updating repo {futures[future]}', file=stderr)
+                continue
             else:
-                print('up to date!')
-                new.append(repo)
+                up_to_date_repos.append(updated_repo)
 
-    new.sort(key=lambda repo: repo.name)
+    up_to_date_repos.sort(key=lambda repo: repo.name)
 
-    if new != list(REPOS):
-        with open(__file__) as f:
+    if up_to_date_repos != list(REPOS):
+        print('Repositories have changed after the update, preparing to write changes...')
+        with open(__file__, encoding='utf-8') as f:
             contents = f.read()
 
         before, begin, rest = contents.partition('# BEGIN\n')
         _, end, rest = rest.partition('# END\n')
 
         new_contents = (
-            'REPOS = (\n' +
-            ''.join(f'{textwrap.indent(repr(r), " " * 4)},\n' for r in new) +
-            ')\n'
+                'REPOS = (\n' +
+                ''.join(f'{textwrap.indent(repr(r), " " * 4)},\n' for r in up_to_date_repos) +
+                ')\n'
         )
         new_contents = ''.join(
             line.replace('\n', '  # noqa: E501\n') if len(line) > 80 else line
             for line in new_contents.splitlines(True)
         )
 
-        print('updating source!')
-        with open(__file__, 'w') as f:
+        print('Writing changes to the disk...')
+        with open(__file__, 'w', encoding='utf-8') as f:
             for part in (before, begin, new_contents, end, rest):
                 f.write(part)
 
@@ -459,13 +538,17 @@ def _update(*, only: Optional[str]) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('command', choices=('download', 'update'))
-    parser.add_argument('--only')
+    # "extend" is a 3.8+ action, which allows passing multiple arguments
+    # to the same command, e.g. ./app --foo 1 2 3 -> {'foo': ['1', '2', '3']}
+    parser.add_argument('--only', action='extend', nargs='+', type=str, default=[])
     args = parser.parse_args()
 
+    only = set(args.only)  # we only care about unique repo names
+
     if args.command == 'download':
-        return _download(only=args.only)
+        return _download(only=only)
     elif args.command == 'update':
-        return _update(only=args.only)
+        return _update(only=only)
     else:
         raise NotImplementedError(args.command)
 


### PR DESCRIPTION
- added concurrent (`ThreadPoolExecutor`) downloads for the `_download` command, had to refactor it a bit and break into smaller pieces
On 4 cores, `python .\bin\download-syntax download`:
**Before:** 33-47s
**After:** 4.9-5s
- added concurrent processing (`ThreadPoolExecutor`) for the `_update` command
On 4 cores, `python .\bin\download-syntax update`:
**Before:** 75-82s
**After:** 37-39s
Well, not THAT huge difference, but I suppose `moby/moby` repo is the bottleneck here, it takes forever to process it
- if one concurrent task fails - log to the `stderr`, other tasks continue to work; we don't want to waste things we already processed :-)
- replaced all path strings with `pathlib.Path` objects when possible; it allows to make reproducible results on both Linux and Windows (slashes/backslashes, uh-oh)
- added `encoding='utf-8'` parameter to all `open` calls, because on some locales on Windows it creates files with incorrect symbols
- added support for passing multiple arguments to the `--only` parameter for both `_download` and `_update` commands. Now you can do `python .\bin\download-syntax download --only MagicStack/MagicPython asottile/language-xml` or  `python .\bin\download-syntax download --only MagicStack/MagicPython --only asottile/language-xml`, both "styles" should work (**warning**: [it is a 3.8+ feature](https://docs.python.org/3.8/library/argparse.html#action) (scroll down to the `extend` action)


**Yes, I messed up** and all the changes were added to a single commit. Sorry!
If you are interested in something particular from the list - please, let me know and I will create a separate PR for it.

If it looks good enough - I may add changes to the README. Let me know what you think. :-)

P. S. [I learned my lesson](https://i.imgur.com/ii90lL2.jpg)