### PR TITLE
Add concurrency to the repos download command

### DIFF
--- a/bin/download-syntax
+++ b/bin/download-syntax
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import concurrent.futures
 import configparser
 import io
 import json
@@ -287,6 +288,51 @@ def _ts_to_js(scope: str, dct: Dict[str, Any]) -> Dict[str, Any]:
     return ret
 
 
+def _download_repo(repo: Repo) -> Set[str]:
+    license_path, _, header = repo.license_path.partition('#')
+    license_url = repo.url(license_path)
+    license_s = urllib.request.urlopen(license_url).read().decode()
+
+    if header:
+        sections = HEADER_RE.split(license_s)
+        for section in sections:
+            if section.startswith(header):
+                _, _, license_s = section.partition('\n')
+                break
+        else:
+            raise AssertionError(f'not found {repo.license_path}')
+
+    # some licenses have trailing whitespace, ugh
+    license_s = TRAILING_WS_RE.sub('', license_s)
+
+    license_filename = os.path.join(_LICENSE_DIR, repo.license_filename)
+    with open(license_filename, 'w', encoding='UTF-8') as f:
+        f.write(f'LICENSE retrieved from {license_url}\n\n')
+        f.write(f'{"-" * 79}\n\n')
+        f.write(f'{license_s.rstrip()}\n')
+
+    downloaded_grammars = set()
+    for grammar in repo.grammars:
+        grammar_s = urllib.request.urlopen(repo.url(grammar)).read()
+        for strategy in _STRATEGIES:
+            try:
+                loaded = strategy(grammar_s)
+            except Exception:
+                continue
+            else:
+                break
+        else:
+            raise AssertionError(f'could not parse {grammar}')
+
+        grammar_name = f'{loaded["scopeName"]}.json'
+        downloaded_grammars.add(grammar_name)
+        grammar_filename = os.path.join(_GRAMMAR_DIR, grammar_name)
+        with open(grammar_filename, 'w', encoding='UTF-8') as f:
+            json.dump(loaded, f)
+            f.write('\n')
+    return downloaded_grammars
+
+
 def _download(*, only: Optional[List[str]]) -> int:
     assert os.path.exists(_GRAMMAR_DIR)
     assert os.path.exists(_LICENSE_DIR)
@@ -294,53 +340,19 @@ def _download(*, only: Optional[List[str]]) -> int:
     licenses: Set[str] = set()
     grammars: Set[str] = set()
 
-    for repo in REPOS:
-        if only is not None and repo.name not in only:
-            continue
-        print(f'{repo.name}...')
+    futures = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for repo in REPOS:
+            if only is not None and repo.name not in only:
+                continue
+            futures[executor.submit(_download_repo, repo)] = repo
 
-        licenses.add(repo.license_filename)
-
-        license_path, _, header = repo.license_path.partition('#')
-        license_url = repo.url(license_path)
-        license_s = urllib.request.urlopen(license_url).read().decode()
-
-        if header:
-            sections = HEADER_RE.split(license_s)
-            for section in sections:
-                if section.startswith(header):
-                    _, _, license_s = section.partition('\n')
-                    break
-            else:
-                raise AssertionError(f'not found {repo.license_path}')
-
-        # some licenses have trailing whitespace, ugh
-        license_s = TRAILING_WS_RE.sub('', license_s)
-
-        license_filename = os.path.join(_LICENSE_DIR, repo.license_filename)
-        with open(license_filename, 'w', encoding='utf-8') as f:
-            f.write(f'LICENSE retrieved from {license_url}\n\n')
-            f.write(f'{"-" * 79}\n\n')
-            f.write(f'{license_s.rstrip()}\n')
-
-        for grammar in repo.grammars:
-            grammar_s = urllib.request.urlopen(repo.url(grammar)).read()
-            for strategy in _STRATEGIES:
-                try:
-                    loaded = strategy(grammar_s)
-                except Exception:
-                    continue
-                else:
-                    break
-            else:
-                raise AssertionError(f'could not parse {grammar}')
-
-            grammar_name = f'{loaded["scopeName"]}.json'
-            grammars.add(grammar_name)
-            grammar_filename = os.path.join(_GRAMMAR_DIR, grammar_name)
-            with open(grammar_filename, 'w', encoding='utf-8') as f:
-                json.dump(loaded, f)
-                f.write('\n')
+        for future in concurrent.futures.as_completed(futures):
+            repo = futures[future]
+            print(f'{repo.name}...')
+            downloaded_grammars = future.result()
+            licenses.add(repo.license_filename)
+            grammars.update(downloaded_grammars)
 
     # similar to what vs code does, derive javascript from typescript
     if only is None or 'microsoft/TypeScript-TmLanguage' in only:


### PR DESCRIPTION
Downloading all the repos took me ~35-40 seconds, which is quite a lot.

With this change it now takes approximately 6-8 seconds on my machine with 4 cores.

While it is not a huge deal, since the tool is used mostly internally, but it looks like a good "quality of life" change with the minimal code-base modifications

a good portion of the code was just moved to a separate function with no additional changes
then, that function is used in the ThreadPool