### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -34,7 +34,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.0
     hooks:

--- a/bin/download-syntax
+++ b/bin/download-syntax
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import concurrent.futures
 import configparser
@@ -13,12 +15,7 @@ import textwrap
 import urllib.parse
 import urllib.request
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import NamedTuple
-from typing import Optional
-from typing import Set
-from typing import Tuple
 
 import cson  # pip install cson
 
@@ -42,8 +39,8 @@ class Repo(NamedTuple):
     name: str
     version: str
     license_path: str
-    grammars: Tuple[str, ...]
-    todo: Optional[str] = None
+    grammars: tuple[str, ...]
+    todo: str | None = None
 
     @property
     def license_filename(self) -> str:
@@ -335,7 +332,7 @@ REPOS = (
 # END
 
 
-def _ts_to_js(scope: str, dct: Dict[str, Any]) -> Dict[str, Any]:
+def _ts_to_js(scope: str, dct: dict[str, Any]) -> dict[str, Any]:
     ret = {}
 
     for k, v in dct.items():
@@ -357,7 +354,7 @@ def _ts_to_js(scope: str, dct: Dict[str, Any]) -> Dict[str, Any]:
     return ret
 
 
-def _download_repo(repo: Repo) -> Set[str]:
+def _download_repo(repo: Repo) -> set[str]:
     license_path, _, header = repo.license_path.partition('#')
     license_url = repo.url(license_path)
     license_s = urllib.request.urlopen(license_url).read().decode()
@@ -402,12 +399,12 @@ def _download_repo(repo: Repo) -> Set[str]:
     return downloaded_grammars
 
 
-def _download(*, only: Optional[List[str]]) -> int:
+def _download(*, only: list[str] | None) -> int:
     assert os.path.exists(_GRAMMAR_DIR)
     assert os.path.exists(_LICENSE_DIR)
 
-    licenses: Set[str] = set()
-    grammars: Set[str] = set()
+    licenses: set[str] = set()
+    grammars: set[str] = set()
 
     futures = {}
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -476,7 +473,7 @@ def _download(*, only: Optional[List[str]]) -> int:
     return 0
 
 
-def _update(*, only: Optional[List[str]]) -> int:
+def _update(*, only: list[str] | None) -> int:
     new = []
     for repo in REPOS:
         if only is not None and repo.name not in only:

--- a/bin/test-grammars
+++ b/bin/test-grammars
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os.path
 from typing import AbstractSet
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -59,7 +58,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.data_files]
 share/babi/grammar_v1 =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos